### PR TITLE
attach pipeline resource for git repo

### DIFF
--- a/controllers/pipelinerun_reconciler.go
+++ b/controllers/pipelinerun_reconciler.go
@@ -63,6 +63,28 @@ func (r *MeteorReconciler) ReconcilePipelineRun(pipelineName string, ctx *contex
 							},
 						},
 					},
+					Resources: []pipelinev1beta1.PipelineResource{
+						{
+							Name: "git-repo",
+							Value: pipelinev1beta1.PipelineResourceSpec{
+								Type: pipelinev1beta1.PipelineResourceTypeGit,
+								Params: []pipelinev1beta1.ResourceParam{
+									{
+										Name: "url",
+										Value: pipelinev1beta1.ArrayOrString{
+											Type: pipelinev1beta1.ParamTypeString,
+											StringVal: meteor.Spec.Url,
+									},
+									{
+										Name: "revision",
+										Value: pipelinev1beta1.ArrayOrString{
+											Type: pipelinev1beta1.ParamTypeString,
+											StringVal: meteor.Spec.Ref,
+									},
+								}
+							},
+						}
+					},
 				},
 			}
 			controllerutil.SetControllerReference(meteor, pipelineRun, r.Scheme)


### PR DESCRIPTION
attach pipeline resource for git repo
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


### Description:

These tekton pipeline resources are used for building this solution.
This would pass resources to the pipeline when triggered. 


PipelineResource: https://github.com/tektoncd/pipeline/blob/1f5980f8c8a05b106687cfa3e5b3193c213cb66e/pkg/apis/resource/v1alpha1/pipeline_resource_types.go#L69
PipelineResourceSpec: https://github.com/tektoncd/pipeline/blob/1f5980f8c8a05b106687cfa3e5b3193c213cb66e/pkg/apis/resource/v1alpha1/pipeline_resource_types.go#L91
ResourceParam:
https://github.com/tektoncd/pipeline/blob/1f5980f8c8a05b106687cfa3e5b3193c213cb66e/pkg/apis/resource/v1alpha1/pipeline_resource_types.go#L112