### PR TITLE
feat: Enable insecure metrics

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,9 @@ patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+# - manager_auth_proxy_patch.yaml
+# Expose unprotected port instead
+- manager_insecure_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/manager_insecure_patch.yaml
+++ b/config/default/manager_insecure_patch.yaml
@@ -1,0 +1,18 @@
+# This patch updates the manager for insecure /metrics scraping
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=:8080"
+        - "--leader-elect"
+        ports:
+          - name: http
+            containerPort: 8080

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
-- monitor.yaml
+# - monitor.yaml
+- monitor_insecure.yaml

--- a/config/prometheus/monitor_insecure.yaml
+++ b/config/prometheus/monitor_insecure.yaml
@@ -1,0 +1,16 @@
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: http
+      scheme: http
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,10 +12,12 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+# - auth_proxy_service.yaml
+# - auth_proxy_role.yaml
+# - auth_proxy_role_binding.yaml
+# - auth_proxy_client_clusterrole.yaml
+# Enable service without proxy
+- service_insecure.yaml
 # Deploy meteor cluster roles
 - meteor_editor_role.yaml
 - meteor_viewer_role.yaml

--- a/config/rbac/service_insecure.yaml
+++ b/config/rbac/service_insecure.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+  selector:
+    control-plane: controller-manager


### PR DESCRIPTION
Remove kubeproxy sidecar and enable metrics scraping. Workarounds https://github.com/operator-framework/operator-sdk/issues/4764