### PR TITLE
refactor: Move phase const to common.go and remove duplicit labels

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -1,0 +1,7 @@
+package v1alpha1
+
+const (
+	PhaseFailed  = "Failed"
+	PhaseRunning = "Building"
+	PhaseOk      = "Ready"
+)

--- a/api/v1alpha1/meteor_types.go
+++ b/api/v1alpha1/meteor_types.go
@@ -125,24 +125,6 @@ func (m *Meteor) GetExpirationTimestamp() time.Time {
 	return m.GetCreationTimestamp().Add(time.Duration(m.Spec.TTL) * time.Second)
 }
 
-const (
-	MeteorPipelineLabel   = "meteor.zone/pipeline"
-	MeteorDeploymentLabel = "meteor.zone/deployment"
-	MeteorLabel           = "meteor.zone/meteor"
-	ODHJupyterHubLabel    = "opendatahub.io/notebook-image"
-)
-
-// Pre-populate labels for children resources
-func (m *Meteor) SeedLabels() map[string]string {
-	return map[string]string{MeteorLabel: string(m.GetUID())}
-}
-
-const (
-	PhaseFailed  = "Failed"
-	PhaseRunning = "Building"
-	PhaseOk      = "Ready"
-)
-
 // Aggregate phase from conditions
 func (m *Meteor) AggregatePhase() string {
 	if len(m.Status.Conditions) == 0 {

--- a/controllers/meteor/pipelinerun_reconciler.go
+++ b/controllers/meteor/pipelinerun_reconciler.go
@@ -29,9 +29,6 @@ func (r *MeteorReconciler) ReconcilePipelineRun(name string, ctx *context.Contex
 
 	logger := log.FromContext(*ctx).WithValues("pipelinerun", namespacedName)
 
-	labels := r.Meteor.SeedLabels()
-	labels[v1alpha1.MeteorPipelineLabel] = name
-
 	updateStatus := func(status metav1.ConditionStatus, reason, message string) {
 		r.UpdateStatus(r.Meteor, "PipelineRun", name, status, reason, message)
 	}
@@ -65,7 +62,6 @@ func (r *MeteorReconciler) ReconcilePipelineRun(name string, ctx *context.Contex
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: req.NamespacedName.Namespace,
-					Labels:    labels,
 				},
 				Spec: pipelinev1beta1.PipelineRunSpec{
 					PipelineRef: &pipelinev1beta1.PipelineRef{


### PR DESCRIPTION
- Phases are not `Meteor` resource specific anymore -> moving to `common.go` so we can expand on them for `Shower`
- Labels are duplicit:
  - `meteo.zone/meteor` label is the same as owner reference.
  - `meteor.zone/pipeline` label is the same as `tekton.dev/pipeline` applied by Openshift Pipelines.