### PR TITLE
Add microshift instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ podman login ...  # to make sure you can push the image to the public registry
 
 make docker-build
 make docker-push
+make install-pipelines
 make deploy
 ```
 
@@ -101,7 +102,63 @@ Run `kubectl proxy` to expose 8001 and access <http://localhost:8001/api/v1/name
 
 Use `kubectl port-forward -n tekton-pipelines service/tekton-dashboard 9097:9097` to expose the tekton dashboard, visit it at <http://localhost:9097/>
 
+## Deploying a local cluster with `microshift`
+
+### A note on MicroShift versions
+
+At the time of this writing (2022-09-07):
+
+- upstream/published versions of [microshift](https://github.com/openshift/microshift) have not been updated for a while, and they are based on a relatively old version of Kubernetes, v1.21.
+- current versions of the Tekton operator require Kubernetes v1.22 or later ([apparently inheriting the requirement from knative](https://github.com/tektoncd/operator/blob/f09e32ac1e238aa1d235923735ea3db2f02f66fe/vendor/knative.dev/pkg/version/version.go#L36)?)
+- the development version of MicroShift is based on OpenShift 4.10, which meets the version requirements:
+
+```
+$ oc version
+Client Version: 4.10.0-202207291637.p0.ge29d58e.assembly.stream-e29d58e
+Kubernetes Version: v1.23.1
+```
+
+### Creating a MicroShift cluster
+
+Follow the instructions of the [MicroShift development environment on RHEL 8](https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md) documentation to set up MicroShift on a virtual machine.
+
+#### Known issues
+
+- As of 2022-09-07, an existing [bug on microshift](https://github.com/openshift/microshift/issues/880) assumes a pre-existing, hardcoded, LVM Volume Group available on the VM, named `rhel`. One quick way to get that is to add an additional virtual disk to your VM (say, `/dev/vdb`) and create the volume group on top of it:
+
+```sh
+sudo lvm pvcreate /dev/vdb
+sudo lvm vgcreate rhel /dev/vdb
+```
+
+#### Getting access to the MicroShift cluster from the host
+
+Assuming that your VM is `cnbi.example.com` and that the `cloud-user` user already has its client configured, you just need to copy the kubeconfig file locally:
+
+```
+$ scp cloud-user@cnbi.example.net:.kube/config /tmp/microshift.config
+$ sed -i -e s/127.0.0.1/cnbi.example.net/ /tmp/microshift.config
+$ export KUBECONFIG=/tmp/microshift.config
+```
+
+### Deploying the required components on MicroShift
+
+```sh
+# Install cert-manager
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+
+# Install tekton-pipelines
+oc create ns tekton-pipelines
+oc adm policy add-scc-to-user anyuid -z tekton-pipelines-controller
+oc adm policy add-scc-to-user anyuid -z tekton-pipelines-webhook
+# FIXME: ugly workaround for fixed UID and version pin due to deprecations in kube 1.25+
+curl -s https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.39.0/release.notags.yaml | grep -vw 65532 | oc apply -f-
+# FIXME: should deploy standard ClusterTasks properly
+curl -s https://api.hub.tekton.dev/v1/resource/tekton/task/openshift-client/0.2/raw | sed -e s/Task/ClusterTask/ | oc apply -f-
+```
+
 ## Testing the operator against an existing cluster
 
+1. `make install-pipelines` will deploy the Tekton pipelines' manifests
 1. `make install` will deploy all our CRD
 2. `make run` will run the controller locally but connected to the cluster.


### PR DESCRIPTION
This adds some information to the README on how to set up a [microshift](https://github.com/openshift/microshift) cluster on a VM for development purposes.

Unfortunately, after completing this I realized that `ImageStream`s are not provided by MicroShift[1] anymore, so this environment will not be enough to test the pipelines that manipulate them.

Still, I hope it is useful information that we can use in the future.

[1] https://github.com/openshift/microshift/pull/788