### PR TITLE
rename namespace set from deployment

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: cnbi-system
+namespace: aicoe-meteor
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named


### PR DESCRIPTION
Disable namespace set from deployment
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


As the component would be deployed via odh operator or argocd 
the namespace should be set via them. 


Once this merged, 
we can switch this pr for review.
https://github.com/operate-first/apps/pull/2398